### PR TITLE
fix: get current user route from pathname

### DIFF
--- a/src/modules/i18n/components/LanguageSwitcher.tsx
+++ b/src/modules/i18n/components/LanguageSwitcher.tsx
@@ -9,7 +9,7 @@ import { appStrings } from '..';
 
 export const LanguageSwitcher: React.FC = () => {
   const { pathname } = useLocation();
-  const { locale, messages } = useIntl();
+  const { messages } = useIntl();
 
   return (
     <ul className={css(list.container)}>
@@ -31,7 +31,7 @@ export const LanguageSwitcher: React.FC = () => {
     /**
      * Get the key of the route the user is currently on
      */
-    const [, route] = pathname.split(locale);
+    const route = pathname.substring(3); // remove local part '/en' from the pathname /en/contact
     const routeKey = Object.keys(messages).find(key => messages[key] === route);
 
     /**


### PR DESCRIPTION
use substring instead of split to get the current user route from a pathname.
this is the result that we will get in this case using split:
'en/legend'.split('en'); 
result : ["", "/leg", "d"]